### PR TITLE
Fix env suffix

### DIFF
--- a/bin/dashwallet.js
+++ b/bin/dashwallet.js
@@ -83,8 +83,10 @@ async function main() {
   let confName = Cli.removeOption(args, ["-c", "--config-name"]);
   if (null !== confName) {
     // intentional empty string on CLI takes precedence over ENVs
-    envSuffix = confName;
+    envSuffix = `.${confName}`;
   }
+  // ..dev => .dev
+  envSuffix = envSuffix.replace(/^\.+/, "+");
 
   /** @type {FsStoreConfig} */
   let storeConfig = {
@@ -310,7 +312,7 @@ let SHORT_VERSION = `${pkg.name} v${pkg.version} - ${pkg.description}`;
 
 function showVersion() {
   console.info(SHORT_VERSION);
-  let sdkVersions = require('./_sdk-versions.js');
+  let sdkVersions = require("./_sdk-versions.js");
   sdkVersions.log(pkg);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashwallet-cli",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashwallet-cli",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@dashincubator/secp256k1": "^1.7.1-5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashwallet-cli",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A more civilized wallet for a less civilized age",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
forwards and backwards compat on leading `.` for env suffix:

```sh
# read from ~/.config/dash.dev/
dashwallet -c 'dev' coins

# also read from ~/.config/dash.dev/
dashwallet -c '.dev' coins

# still read from ~/.config/dash.dev/
DASH_ENV='dev' dashwallet coins
```